### PR TITLE
Flushbar version restricted to 1.5.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
   dio: 2.1.6
 
   # A flexible widget for user notification.
-  flushbar: ^1.5.3
+  flushbar: 1.5.3
 
 
 dev_dependencies:


### PR DESCRIPTION
application crashes on higher version on Flushbar, found on flushbar version 1.6.0